### PR TITLE
PIE1483 Remove identifier from Android test collector payload

### DIFF
--- a/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/InstrumentedTestCollector.kt
+++ b/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/InstrumentedTestCollector.kt
@@ -74,7 +74,6 @@ abstract class InstrumentedTestCollector(
         val testDetails = TestDetails(
             scope = test.testClass.name,
             name = test.methodName,
-            identifier = "${test.className}.${test.methodName}",
             location = test.className,
             fileName = null,
             result = testObserver.result,

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/models/TestDetails.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/models/TestDetails.kt
@@ -7,7 +7,6 @@ data class TestDetails(
     @SerializedName("id") val id: String = generateUUID(),
     @SerializedName("scope") val scope: String?,
     @SerializedName("name") val name: String,
-    @SerializedName("identifier") val identifier: String,
     @SerializedName("location") val location: String?,
     @SerializedName("file_name") val fileName: String?,
     @SerializedName("result") val result: TraceResult,

--- a/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestCollectorPlugin.kt
+++ b/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestCollectorPlugin.kt
@@ -78,7 +78,6 @@ class UnitTestCollectorPlugin : Plugin<Project> {
                     val testDetails = TestDetails(
                         scope = test.className,
                         name = test.displayName,
-                        identifier = "${test.className}.${test.displayName}",
                         location = test.className,
                         fileName = null,
                         result = testObserver.result,


### PR DESCRIPTION
## 💬 Summary of Changes

We have removed identifier field from DB test table, and we no longer using it in TA.
This PR is for removing identifier from this collector so that they stop sending identifier to TA. [We'll not make a release for this PR](https://linear.app/buildkite/issue/PIE-1427#comment-9ea47561)

Ticket: https://linear.app/buildkite/issue/PIE-1483/remove-identifier-from-android-test-collector-payload
Parent ticket: https://linear.app/buildkite/issue/PIE-1427/remove-identifier-from-test-collector-payloads


## 📝 Items of Note
I don't have Android development experience. I'm actually not sure how to verify the changes in this PR/or adding unit tests for it. The build seems to be happy tho. 