### PR TITLE
Fix workflow/build failure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ buildscript {
 
     dependencies {
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.20.0")
-        classpath("com.buildkite.test-collector-android:unit-test-collector-plugin:0.1.0")
     }
 }
 

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/TestDataUploader.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/TestDataUploader.kt
@@ -10,7 +10,7 @@ import com.buildkite.test.collector.android.util.Constants.Collector
 import retrofit2.Response
 
 class TestDataUploader(
-    val testSuiteApiToken: String,
+    val testSuiteApiToken: String?,
     val isDebugEnabled: Boolean
 ) {
     fun configureUploadData(testCollection: List<TestDetails>) {
@@ -26,14 +26,18 @@ class TestDataUploader(
     }
 
     private fun uploadTestData(testData: TestData) {
-        val retroService = RetrofitInstance.getRetrofitInstance(testSuiteApiToken = testSuiteApiToken)
-            .create(TestUploaderApi::class.java)
-        val uploadTestDataApiCall = retroService.uploadTestData(testData = testData)
+        if (testSuiteApiToken == null) {
+            println("Buildkite test suite API token is missing. Please set up your API token environment variable to upload the analytics data. Follow [README] for further information.")
+        } else {
+            val retroService = RetrofitInstance.getRetrofitInstance(testSuiteApiToken = testSuiteApiToken)
+                .create(TestUploaderApi::class.java)
+            val uploadTestDataApiCall = retroService.uploadTestData(testData = testData)
 
-        val executeApiCall = uploadTestDataApiCall.execute()
+            val executeApiCall = uploadTestDataApiCall.execute()
 
-        if (isDebugEnabled) {
-            logApiResponse(executeApiCall)
+            if (isDebugEnabled) {
+                logApiResponse(executeApiCall)
+            }
         }
     }
 

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/environment/UploaderConfiguration.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/environment/UploaderConfiguration.kt
@@ -13,11 +13,11 @@ fun configureInstrumentedTestUploader(
     apiToken: String,
     isDebugEnabled: Boolean
 ) = TestDataUploader(
-    testSuiteApiToken = apiToken,
+    testSuiteApiToken = apiToken.takeIf { token -> token != "null" },
     isDebugEnabled = isDebugEnabled
 )
 
-private fun getStringEnvironmentValue(name: String): String {
+private fun getStringEnvironmentValue(name: String): String? {
     return System.getenv(name)
 }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("com.buildkite.test-collector-android.unit-test-collector-plugin")
 }
 
 android {


### PR DESCRIPTION
## 💬 Summary of Changes

This pull request resolves two issues that were causing build and workflow failures:

1. De-referenced the published test collector plugin.

2. Handled the API token environment variable null scenario: The API token is retrieved from the system environment variable, which can be null when not set. This pull request adds a check to handle these scenarios for both instrumented test collector library and unit test collector plugin, and prints a log message that informs about the missing token.
