### PR TITLE
Update collector version name that gets uploaded with analytics data

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ environment variables, so no additional config is required.
 #### Bumping Version
 
 When bumping the version, update the version in `gradle.properties` as well as `RunEnvironment.VERSION_NAME`.
+Avoid using the -SNAPSHOT suffix in RunEnvironment.VERSION_NAME, since it gets be removed automatically upon release. This ensure that we send the accurate library version name.
 
 This ensures the correct library version is uploaded alongside the test analytics.
 

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/models/RunEnvironment.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/models/RunEnvironment.kt
@@ -46,7 +46,7 @@ data class RunEnvironment(
     companion object {
         // When bumping version, update VERSION_NAME to match new version
         // Used for uploading correct library version
-        val VERSION_NAME = "0.2.0-SNAPSHOT"
+        val VERSION_NAME = "0.2.0"
         val COLLECTOR_NAME = "android-buildkite-test-collector"
     }
 }


### PR DESCRIPTION
## 💬 Summary of Changes

This PR follows up on [this change](https://github.com/buildkite/test-collector-android/pull/10) and removes the -SNAPSHOT suffix from the RunEnvironment.VERSION_NAME that's included with the analytic data.

Since this suffix is automatically removed upon a new release, removing it beforehand ensures that the library version name is accurate and up-to-date when analytic data is sent.

As such, we should avoid using the -SNAPSHOT suffix in RunEnvironment.VERSION_NAME to keep version name accurate.