### PR TITLE
Fix release workflow pipeline timing out on staging repository

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,8 @@ POM_DEVELOPER_ID=buildkite
 POM_DEVELOPER_NAME=Buildkite
 POM_DEVELOPER_URL=https://github.com/buildkite
 
+SONATYPE_CONNECT_TIMEOUT_SECONDS=180
+
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
## 💬 Summary of Changes
Currently, the release workflow is failing to publish the library to maven central.

```
* What went wrong:
Execution failed for task ':collector:instrumented-test-collector:createStagingRepository'.
> A failure occurred while executing com.vanniktech.maven.publish.sonatype.CreateSonatypeRepositoryTask$CreateStagingRepository
   > timeout
```

Apparently this can be common and we can increase the connection timeout to see if it fixes this problem:
https://vanniktech.github.io/gradle-maven-publish-plugin/central/#timeouts

Attempting to fix the issue by increasing the timeout to 3 mins.

## 🧾 Checklist

<!-- Actions you should have taken before opening this pull request. -->

- [x] 🧐 Performed a self-review of the changes
- [ ] ✅ Added tests to cover changes
- [ ] 🏎 Ran Unit Tests and they all passed
- [ ] 🏷 Labeled this PR appropriately


## 📝 Items of Note

<!--
Document anything here that you think the reviewer(s) of this PR may need to know or anything of
specific interest.
-->
