### PR TITLE
Bump the next version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In your app-level build.gradle.kts, add the following plugin:
 
 ```
 plugins {
-    id("com.buildkite.test-collector-android.unit-test-collector-plugin").version("0.2.0")
+    id("com.buildkite.test-collector-android.unit-test-collector-plugin").version("0.3.0")
 }
 ```
 
@@ -37,7 +37,7 @@ In your app-level build.gradle.kts file,
 Add the following dependency:
 
 ```
-androidTestImplementation("com.buildkite.test-collector-android:instrumented-test-collector:0.2.0")
+androidTestImplementation("com.buildkite.test-collector-android:instrumented-test-collector:0.3.0")
 ```
 
 Again, in your app-level build.gradle.kts file, instruct Gradle to use your test collector and pass analytics token argument:

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/model/RunEnvironment.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/model/RunEnvironment.kt
@@ -33,7 +33,7 @@ data class RunEnvironment(
     companion object {
         // When bumping version, update VERSION_NAME to match new version
         // Used for uploading correct library version
-        const val VERSION_NAME = "0.3.0"
+        const val VERSION_NAME = "0.4.0"
         const val COLLECTOR_NAME = "android-buildkite-test-collector"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.buildkite.test-collector-android
 # When bumping version, update RunEnvironment.VERSION_NAME
-VERSION_NAME=0.3.0-SNAPSHOT
+VERSION_NAME=0.4.0-SNAPSHOT
 
 POM_URL=https://github.com/buildkite/test-collector-android
 POM_SCM_URL=https://github.com/buildkite/test-collector-android


### PR DESCRIPTION
## 💬 Summary of Changes

<!-- Provide a high level description & summary of what your PR is going to change. -->

Because the version `0.3.0` has been released, this PR bumps the next version, so the future builds will use the next version `0.4.0-SNAPSHOT`. I follow #19.

We have also rotated the GPG key to sign the collector. If we merge this PR, we could verify whether the signing is working with the new key when publishing the SNAPSHOT to Maven.

## 🧾 Checklist

<!-- Actions you should have taken before opening this pull request. -->

- [x] 🧐 Performed a self-review of the changes
- [ ] ✅ Added tests to cover changes
- [ ] 🏎 Ran Unit Tests and they all passed
- [ ] 🏷 Labeled this PR appropriately


## 📝 Items of Note

<!--
Document anything here that you think the reviewer(s) of this PR may need to know or anything of
specific interest.
-->
This won't create the release or publish artifact with `0.4.0`. 