### PR TITLE
Add mise configuration for JDK 17

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-17"


### PR DESCRIPTION
## Description

Add a `.mise.toml` to manage JDK 17 via [mise](https://mise.jdx.dev/), the project's only system-level dependency.

## Context

The project requires JDK 17 (`build-logic/convention/build.gradle.kts` sets source/target compatibility to Java 17, and Kotlin 1.8.22 doesn't support JVM target 21). Without JDK 17 installed, the build fails.

Gradle itself is managed by the wrapper (`gradlew` + `gradle-wrapper.properties`), so only the JDK needs external management.

## Changes

- Add `.mise.toml` pinning `java = "temurin-17"` (currently resolves to 17.0.18+8)