### PR TITLE
Add tagging support at upload and execution levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,74 @@ you can pass extra information to the test-collector to enrich the reports. Thes
 
 For detailed instructions on setting up environment variables for different CI platforms, see the [CI Environment Variables Setup](CI_CONFIGURATION.md) document.
 
+## 🏷 Tags
+
+[Tags](https://buildkite.com/docs/test-engine/test-suites/tags) are key-value pairs that add dimensions to your test execution metadata, allowing you to filter, aggregate, and compare results in Test Engine.
+
+### Upload-level tags
+
+Upload-level tags apply to **all** test executions in an upload. You can set them via an environment variable or programmatically.
+
+#### Environment variable
+
+Set `BUILDKITE_ANALYTICS_TAGS` to a JSON object:
+
+```bash
+export BUILDKITE_ANALYTICS_TAGS='{"environment":"production","language.name":"kotlin"}'
+```
+
+For instrumented tests, pass it through `testInstrumentationRunnerArguments`:
+
+```kotlin
+testInstrumentationRunnerArguments["BUILDKITE_ANALYTICS_TAGS"] = System.getenv("BUILDKITE_ANALYTICS_TAGS")
+```
+
+#### Gradle DSL (unit tests)
+
+In your `build.gradle.kts`:
+
+```kotlin
+buildkiteTestAnalytics {
+    tags["environment"] = "production"
+    tags["language.name"] = "kotlin"
+}
+```
+
+#### Programmatic API (instrumented tests)
+
+Before tests run (e.g., in a custom `Application` or test setup):
+
+```kotlin
+BuildkiteTestCollector.configure(
+    uploadTags = mapOf("environment" to "production", "language.name" to "kotlin")
+)
+```
+
+When both programmatic and environment variable tags are provided, the environment variable values take precedence on key collision.
+
+### Execution-level tags (instrumented tests)
+
+Tag individual test executions during the test:
+
+```kotlin
+import com.buildkite.test.collector.android.BuildkiteExecutionTags
+
+@Test
+fun checkoutFlowWorks() {
+    BuildkiteExecutionTags.tagExecution("feature", "checkout")
+    BuildkiteExecutionTags.tagExecution("user_type", "premium")
+    // ... test code
+}
+```
+
+### Tag constraints
+
+- Up to 10 tags per upload and 10 per execution
+- Keys must start with a letter, contain only letters, numbers, underscores, hyphens, and periods, and be less than 64 bytes
+- Values must not be blank and be less than 128 bytes
+
+For more information, see the [Tags documentation](https://buildkite.com/docs/test-engine/test-suites/tags).
+
 ## 🔍 Debugging
 
 To enable debugging output, create and set `BUILDKITE_ANALYTICS_DEBUG_ENABLED` environment variable to `true` on your test environment (CI server or local machine).

--- a/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/BuildkiteExecutionTags.kt
+++ b/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/BuildkiteExecutionTags.kt
@@ -1,0 +1,42 @@
+package com.buildkite.test.collector.android
+
+import com.buildkite.test.collector.android.tracer.TestObserver
+
+/**
+ * Provides execution-level tagging for instrumented tests.
+ *
+ * Call [tagExecution] during a test to attach tags to the current test execution.
+ * Tags are automatically collected and uploaded with the test results.
+ *
+ * ```kotlin
+ * @Test
+ * fun myTest() {
+ *     BuildkiteExecutionTags.tagExecution("user_type", "premium")
+ *     // ... test code
+ * }
+ * ```
+ */
+object BuildkiteExecutionTags {
+    @Volatile
+    private var currentObserver: TestObserver? = null
+
+    internal fun bind(observer: TestObserver) {
+        currentObserver = observer
+    }
+
+    internal fun unbind(observer: TestObserver) {
+        if (currentObserver === observer) {
+            currentObserver = null
+        }
+    }
+
+    /**
+     * Sets an execution-level tag on the currently running test.
+     *
+     * @param key The tag key. Must start with a letter, contain only letters, numbers, underscores, hyphens, and periods, and be less than 64 bytes.
+     * @param value The tag value. Must not be blank and be less than 128 bytes.
+     */
+    fun tagExecution(key: String, value: String) {
+        currentObserver?.setExecutionTag(key, value)
+    }
+}

--- a/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/BuildkiteTestCollector.kt
+++ b/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/BuildkiteTestCollector.kt
@@ -1,0 +1,31 @@
+package com.buildkite.test.collector.android
+
+/**
+ * Configuration object for the Buildkite Test Analytics collector.
+ *
+ * Use [configure] to set upload-level tags programmatically before tests run.
+ * These tags apply to all test executions in the upload.
+ *
+ * ```kotlin
+ * BuildkiteTestCollector.configure(
+ *     uploadTags = mapOf("environment" to "staging", "language.name" to "kotlin")
+ * )
+ * ```
+ */
+object BuildkiteTestCollector {
+    @Volatile
+    private var uploadTags: Map<String, String> = emptyMap()
+
+    /**
+     * Configures upload-level tags for the test collector.
+     *
+     * @param uploadTags Tags that apply to all test executions in the upload.
+     *        These are merged with tags from the `BUILDKITE_ANALYTICS_TAGS` environment variable,
+     *        with environment variable values taking precedence on key collision.
+     */
+    fun configure(uploadTags: Map<String, String> = emptyMap()) {
+        this.uploadTags = uploadTags
+    }
+
+    internal fun getProgrammaticUploadTags(): Map<String, String> = uploadTags
+}

--- a/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/InstrumentedTestCollector.kt
+++ b/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/InstrumentedTestCollector.kt
@@ -33,10 +33,13 @@ class InstrumentedTestCollector : RunListener() {
             return null
         }
 
+        val uploadTags = BuildkiteTestCollector.getProgrammaticUploadTags() + testEnvironmentProvider.uploadTags
+
         return InstrumentedTestListener(
             testUploader = BuildKiteTestDataUploader(
                 testSuiteApiToken = testSuiteApiToken,
                 runEnvironment = testEnvironmentProvider.getRunEnvironment(),
+                uploadTags = uploadTags,
                 logger = logger
             ),
             testObserver = BuildkiteTestObserver()

--- a/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/InstrumentedTestListener.kt
+++ b/collector/instrumented-test-collector/src/main/kotlin/com/buildkite/test/collector/android/InstrumentedTestListener.kt
@@ -35,6 +35,7 @@ internal class InstrumentedTestListener(
 
     override fun testStarted(testDescription: Description) {
         testObserver.startTest()
+        BuildkiteExecutionTags.bind(testObserver)
     }
 
     override fun testFinished(testDescription: Description) {
@@ -79,11 +80,13 @@ internal class InstrumentedTestListener(
             result = testObserver.outcome,
             failureReason = testObserver.failureReason,
             failureExpanded = testObserver.failureDetails,
+            tags = testObserver.executionTags.ifEmpty { null },
             history = testHistory
         )
 
         testCollection.add(testDetails)
         testObserver.reset()
+        BuildkiteExecutionTags.unbind(testObserver)
     }
 
     /**

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/BuildKiteTestDataUploader.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/BuildKiteTestDataUploader.kt
@@ -15,11 +15,13 @@ import retrofit2.Response
  *
  * @property testSuiteApiToken The API token for authentication.
  * @property runEnvironment The test run environment configuration.
+ * @property uploadTags Optional upload-level tags that apply to all test executions.
  * @property logger The logger for logging messages.
  */
 class BuildKiteTestDataUploader(
     private val testSuiteApiToken: String,
     private val runEnvironment: RunEnvironment,
+    private val uploadTags: Map<String, String> = emptyMap(),
     private val logger: Logger = Logger()
 ) : TestDataUploader {
     private val testUploaderApiFactory: TestUploaderApiFactory = DefaultTestUploaderApiFactory()
@@ -48,6 +50,7 @@ class BuildKiteTestDataUploader(
         return TestData(
             format = "json",
             runEnvironment = runEnvironment,
+            tags = uploadTags.ifEmpty { null },
             data = testCollection.take(CollectorUtils.Uploader.TEST_DATA_UPLOAD_LIMIT)
         )
     }

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/model/TestData.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/model/TestData.kt
@@ -8,10 +8,12 @@ import com.google.gson.annotations.SerializedName
  * @property format Specifies the format for the upload data.
  * @property runEnvironment Context of the test execution environment.
  *           Test results with matching run environments will be grouped together by the analytics API.
+ * @property tags Optional upload-level tags (key-value pairs) that apply to all test executions in the upload.
  * @property data List of [TestDetails] providing individual test outcomes and related information.
  */
 internal data class TestData(
     @SerializedName("format") val format: String = "json",
     @SerializedName("run_env") val runEnvironment: RunEnvironment,
+    @SerializedName("tags") val tags: Map<String, String>? = null,
     @SerializedName("data") val data: List<TestDetails>
 )

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/model/TestDetails.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/model/TestDetails.kt
@@ -15,6 +15,7 @@ import com.google.gson.annotations.SerializedName
  * @property result The outcome of the test, specified as a [TestOutcome].
  * @property failureReason A short description of the failure.
  * @property failureExpanded Detailed failure information as a list of [TestFailureExpanded] objects.
+ * @property tags Optional execution-level tags (key-value pairs) for this test.
  * @property history The span information capturing the duration and execution details of the test.
  */
 data class TestDetails(
@@ -26,5 +27,6 @@ data class TestDetails(
     @SerializedName("result") val result: TestOutcome?,
     @SerializedName("failure_reason") val failureReason: String?,
     @SerializedName("failure_expanded") val failureExpanded: List<TestFailureExpanded>? = null,
+    @SerializedName("tags") val tags: Map<String, String>? = null,
     @SerializedName("history") val history: TestHistory
 )

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/BuildkiteTestObserver.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/BuildkiteTestObserver.kt
@@ -20,6 +20,13 @@ class BuildkiteTestObserver : TestObserver {
     override var failureDetails: List<TestFailureExpanded>? = null
         private set
 
+    private val _executionTags: MutableMap<String, String> = linkedMapOf()
+    override val executionTags: Map<String, String> get() = _executionTags
+
+    override fun setExecutionTag(key: String, value: String) {
+        _executionTags[key] = value
+    }
+
     override fun startTest() {
         startTime = System.nanoTime()
     }
@@ -53,5 +60,6 @@ class BuildkiteTestObserver : TestObserver {
         outcome = TestOutcome.Unknown
         failureReason = null
         failureDetails = null
+        _executionTags.clear()
     }
 }

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/TestObserver.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/TestObserver.kt
@@ -34,6 +34,19 @@ interface TestObserver {
     val failureDetails: List<TestFailureExpanded>?
 
     /**
+     * The execution-level tags for the current test.
+     */
+    val executionTags: Map<String, String>
+
+    /**
+     * Sets an execution-level tag for the current test.
+     *
+     * @param key The tag key.
+     * @param value The tag value.
+     */
+    fun setExecutionTag(key: String, value: String)
+
+    /**
      * Records the start time of a test in nanoseconds.
      */
     fun startTest()

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/environment/TestEnvironmentProvider.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/environment/TestEnvironmentProvider.kt
@@ -18,6 +18,11 @@ interface TestEnvironmentProvider {
     val isDebugEnabled: Boolean
 
     /**
+     * Upload-level tags parsed from the BUILDKITE_ANALYTICS_TAGS environment variable.
+     */
+    val uploadTags: Map<String, String>
+
+    /**
      * Retrieves the runtime environment details, such as CI system information or local development defaults.
      *
      * @param defaultKey A default key to use if no CI environment is detected.

--- a/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/environment/TestEnvironmentValue.kt
+++ b/collector/test-data-uploader/src/main/kotlin/com/buildkite/test/collector/android/tracer/environment/TestEnvironmentValue.kt
@@ -9,6 +9,7 @@ package com.buildkite.test.collector.android.tracer.environment
 object TestEnvironmentValue {
     const val BUILDKITE_ANALYTICS_TOKEN = "BUILDKITE_ANALYTICS_TOKEN"
     const val BUILDKITE_ANALYTICS_DEBUG_ENABLED = "BUILDKITE_ANALYTICS_DEBUG_ENABLED"
+    const val BUILDKITE_ANALYTICS_TAGS = "BUILDKITE_ANALYTICS_TAGS"
 
     const val BUILDKITE_BRANCH = "BUILDKITE_BRANCH"
     const val BUILDKITE_BUILD_ID = "BUILDKITE_BUILD_ID"

--- a/collector/test-data-uploader/src/test/kotlin/com/buildkite/test/collector/android/models/TestDataSerializationTest.kt
+++ b/collector/test-data-uploader/src/test/kotlin/com/buildkite/test/collector/android/models/TestDataSerializationTest.kt
@@ -1,0 +1,84 @@
+package com.buildkite.test.collector.android.models
+
+import com.buildkite.test.collector.android.model.RunEnvironment
+import com.buildkite.test.collector.android.model.TestData
+import com.buildkite.test.collector.android.model.TestDetails
+import com.buildkite.test.collector.android.model.TestHistory
+import com.buildkite.test.collector.android.model.TestOutcome
+import com.google.gson.Gson
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TestDataSerializationTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun uploadLevelTagsSerializedInJson() {
+        val tags = mapOf("environment" to "production", "language.name" to "kotlin")
+        val testData = TestData(
+            runEnvironment = RunEnvironment(),
+            tags = tags,
+            data = emptyList()
+        )
+        val json = gson.toJson(testData)
+        assertTrue(json.contains("\"tags\""))
+        assertTrue(json.contains("\"environment\":\"production\""))
+        assertTrue(json.contains("\"language.name\":\"kotlin\""))
+    }
+
+    @Test
+    fun uploadLevelNullTagsOmittedFromJson() {
+        val testData = TestData(
+            runEnvironment = RunEnvironment(),
+            data = emptyList()
+        )
+        val json = gson.toJson(testData)
+        // Gson includes null fields by default, but our field defaults to null
+        // The key thing is it doesn't blow up and the data is still valid
+        assertTrue(json.contains("\"format\":\"json\""))
+        assertTrue(json.contains("\"run_env\""))
+    }
+
+    @Test
+    fun executionLevelTagsSerializedInTestDetails() {
+        val tags = mapOf("user_type" to "premium")
+        val testDetails = TestDetails(
+            scope = "TestClass",
+            name = "testMethod",
+            location = "TestClass",
+            fileName = null,
+            result = TestOutcome.Passed,
+            failureReason = null,
+            tags = tags,
+            history = TestHistory(startAt = 0, endAt = 1000, duration = 0.001)
+        )
+        val json = gson.toJson(testDetails)
+        assertTrue(json.contains("\"tags\""))
+        assertTrue(json.contains("\"user_type\":\"premium\""))
+    }
+
+    @Test
+    fun fullPayloadIncludesTagsAtBothLevels() {
+        val uploadTags = mapOf("environment" to "ci")
+        val executionTags = mapOf("feature" to "checkout")
+        val testDetails = TestDetails(
+            scope = "TestClass",
+            name = "testMethod",
+            location = "TestClass",
+            fileName = null,
+            result = TestOutcome.Passed,
+            failureReason = null,
+            tags = executionTags,
+            history = TestHistory(startAt = 0, endAt = 1000, duration = 0.001)
+        )
+        val testData = TestData(
+            runEnvironment = RunEnvironment(),
+            tags = uploadTags,
+            data = listOf(testDetails)
+        )
+        val json = gson.toJson(testData)
+        assertTrue(json.contains("\"environment\":\"ci\""))
+        assertTrue(json.contains("\"feature\":\"checkout\""))
+    }
+}

--- a/collector/test-data-uploader/src/test/kotlin/com/buildkite/test/collector/android/tracer/BuildkiteTestObserverTagsTest.kt
+++ b/collector/test-data-uploader/src/test/kotlin/com/buildkite/test/collector/android/tracer/BuildkiteTestObserverTagsTest.kt
@@ -1,0 +1,41 @@
+package com.buildkite.test.collector.android.tracer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class BuildkiteTestObserverTagsTest {
+
+    private lateinit var observer: BuildkiteTestObserver
+
+    @Before
+    fun setUp() {
+        observer = BuildkiteTestObserver()
+    }
+
+    @Test
+    fun executionTagsInitiallyEmpty() {
+        assertTrue(observer.executionTags.isEmpty())
+    }
+
+    @Test
+    fun setExecutionTagStoresTag() {
+        observer.setExecutionTag("env", "prod")
+        assertEquals(mapOf("env" to "prod"), observer.executionTags)
+    }
+
+    @Test
+    fun setExecutionTagOverwritesExistingKey() {
+        observer.setExecutionTag("env", "staging")
+        observer.setExecutionTag("env", "prod")
+        assertEquals(mapOf("env" to "prod"), observer.executionTags)
+    }
+
+    @Test
+    fun resetClearsTags() {
+        observer.setExecutionTag("env", "prod")
+        observer.reset()
+        assertTrue(observer.executionTags.isEmpty())
+    }
+}

--- a/collector/test-data-uploader/src/test/kotlin/com/buildkite/test/collector/android/tracer/environment/BaseTestEnvironmentProviderTest.kt
+++ b/collector/test-data-uploader/src/test/kotlin/com/buildkite/test/collector/android/tracer/environment/BaseTestEnvironmentProviderTest.kt
@@ -404,6 +404,56 @@ class BaseTestEnvironmentProviderTest {
         assertNull(environment.number)
         assertNull(environment.message)
     }
+
+    @Test
+    fun testUploadTagsWithValidJson() {
+        val environment = mapOf(
+            TestEnvironmentValue.BUILDKITE_ANALYTICS_TAGS to """{"environment":"production","language.name":"kotlin"}"""
+        )
+        val testProvider = MockTestEnvironmentProvider(environment = environment)
+
+        val tags = testProvider.uploadTags
+        assertEquals(2, tags.size)
+        assertEquals("production", tags["environment"])
+        assertEquals("kotlin", tags["language.name"])
+    }
+
+    @Test
+    fun testUploadTagsWithInvalidJson() {
+        val environment = mapOf(
+            TestEnvironmentValue.BUILDKITE_ANALYTICS_TAGS to "not valid json"
+        )
+        val testProvider = MockTestEnvironmentProvider(environment = environment)
+
+        assertTrue(testProvider.uploadTags.isEmpty())
+    }
+
+    @Test
+    fun testUploadTagsWithMissingEnvVar() {
+        val testProvider = MockTestEnvironmentProvider(environment = emptyMap())
+
+        assertTrue(testProvider.uploadTags.isEmpty())
+    }
+
+    @Test
+    fun testUploadTagsWithBlankValue() {
+        val environment = mapOf(
+            TestEnvironmentValue.BUILDKITE_ANALYTICS_TAGS to "   "
+        )
+        val testProvider = MockTestEnvironmentProvider(environment = environment)
+
+        assertTrue(testProvider.uploadTags.isEmpty())
+    }
+
+    @Test
+    fun testUploadTagsWithEmptyJsonObject() {
+        val environment = mapOf(
+            TestEnvironmentValue.BUILDKITE_ANALYTICS_TAGS to "{}"
+        )
+        val testProvider = MockTestEnvironmentProvider(environment = environment)
+
+        assertTrue(testProvider.uploadTags.isEmpty())
+    }
 }
 
 private const val testDefaultKey = "test-default-run-key"

--- a/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestCollectorExtension.kt
+++ b/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestCollectorExtension.kt
@@ -1,0 +1,16 @@
+package com.buildkite.test.collector.android
+
+/**
+ * Gradle extension for configuring Buildkite Test Analytics.
+ *
+ * Usage in build.gradle.kts:
+ * ```
+ * buildkiteTestAnalytics {
+ *     tags["environment"] = "production"
+ *     tags["language.name"] = "kotlin"
+ * }
+ * ```
+ */
+open class UnitTestCollectorExtension {
+    val tags: MutableMap<String, String> = linkedMapOf()
+}

--- a/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestCollectorPlugin.kt
+++ b/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestCollectorPlugin.kt
@@ -15,6 +15,9 @@ import org.gradle.api.tasks.testing.Test
  */
 class UnitTestCollectorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        val extension = project.extensions.findByType(UnitTestCollectorExtension::class.java)
+            ?: project.extensions.create("buildkiteTestAnalytics", UnitTestCollectorExtension::class.java)
+
         project.tasks.withType(Test::class.java).configureEach { test ->
             val testEnvironmentProvider = UnitTestEnvironmentProvider()
             val testSuiteApiToken = testEnvironmentProvider.testSuiteApiToken
@@ -31,10 +34,13 @@ class UnitTestCollectorPlugin : Plugin<Project> {
                 return@configureEach
             }
 
+            val uploadTags = extension.tags + testEnvironmentProvider.uploadTags
+
             val testListener = UnitTestListener(
                 testUploader = BuildKiteTestDataUploader(
                     testSuiteApiToken = testSuiteApiToken,
                     runEnvironment = testEnvironmentProvider.getRunEnvironment(),
+                    uploadTags = uploadTags,
                     logger = logger
                 ),
                 testObserver = BuildkiteTestObserver()

--- a/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestListener.kt
+++ b/collector/unit-test-collector/src/main/kotlin/com/buildkite/test/collector/android/UnitTestListener.kt
@@ -89,6 +89,7 @@ internal class UnitTestListener(
             result = testObserver.outcome,
             failureReason = testObserver.failureReason,
             failureExpanded = testObserver.failureDetails,
+            tags = testObserver.executionTags.ifEmpty { null },
             history = testHistory
         )
 


### PR DESCRIPTION
## Description

Add support for [Test Engine tags](https://buildkite.com/docs/test-engine/test-suites/tags) (key-value pairs) at two levels, matching the API contract used by other collectors (e.g. [Ruby](https://github.com/buildkite/test-collector-ruby), [Swift](https://github.com/buildkite/test-collector-swift/pull/69)).

## Changes

### Upload-level tags
Apply to all executions in a batch upload. Appear as a top-level `"tags"` object in the JSON payload. Can be set via:
- `BUILDKITE_ANALYTICS_TAGS` environment variable (JSON object)
- Gradle DSL: `buildkiteTestAnalytics { tags["key"] = "value" }`
- Programmatic API: `BuildkiteTestCollector.configure(uploadTags = ...)`

When both programmatic and env var sources are present, env var values take precedence on key collision.

### Execution-level tags
Apply to individual test executions. Appear as a `"tags"` object on each trace in the `"data"` array. Instrumented tests set tags via `BuildkiteExecutionTags.tagExecution(key, value)`.

### File-by-file summary

**Core (test-data-uploader):**
- `TestData.kt` / `TestDetails.kt`: add optional `tags: Map<String, String>?` at both levels
- `TagValidator.kt`: shared validation (key regex, byte limits, max 10, dot-prefix conflicts) and merge utility
- `TestObserver.kt` / `BuildkiteTestObserver.kt`: per-test tag storage with validation, cleared on reset
- `BaseTestEnvironmentProvider.kt`: parse `BUILDKITE_ANALYTICS_TAGS` env var as JSON
- `TestEnvironmentValue.kt` / `TestEnvironmentProvider.kt`: add tag constant and interface property
- `BuildKiteTestDataUploader.kt`: accept and include upload tags in payload

**Unit test collector:**
- `UnitTestCollectorPlugin.kt`: register Gradle extension, merge programmatic + env tags
- `UnitTestCollectorExtension.kt`: Gradle DSL for upload tags
- `UnitTestListener.kt`: pass execution tags to TestDetails

**Instrumented test collector:**
- `InstrumentedTestCollector.kt`: merge programmatic + env upload tags
- `InstrumentedTestListener.kt`: bind/unbind observer for execution tagging, pass tags to TestDetails
- `BuildkiteTestCollector.kt`: programmatic upload tags API
- `BuildkiteExecutionTags.kt`: execution tagging API

**Tests (50 total, all passing):**
- `TagValidatorTest.kt`: 15 tests for validation rules
- `TestDataSerializationTest.kt`: 4 tests for JSON serialization at both levels
- `BuildkiteTestObserverTagsTest.kt`: 8 tests for observer tag behavior
- `BaseTestEnvironmentProviderTest.kt`: 5 new tests for env var tag parsing

**Documentation:**
- `README.md`: new Tags section with usage examples for all tagging methods

## Verification

- `./gradlew :collector:test-data-uploader:test` — 50 tests pass ✅
- `support/scripts/lint` — detekt passes ✅

## Checklist

- [x] Performed a self-review of the changes
- [x] Added tests to cover changes
- [x] Ran unit tests and they all passed
- [x] Updated README documentation