### PR TITLE
Release 0.4.0: tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In your app-level build.gradle.kts, add the following plugin:
 
 ```
 plugins {
-    id("com.buildkite.test-collector-android.unit-test-collector-plugin").version("0.3.0")
+    id("com.buildkite.test-collector-android.unit-test-collector-plugin").version("0.4.0")
 }
 ```
 
@@ -37,7 +37,7 @@ In your app-level build.gradle.kts file,
 Add the following dependency:
 
 ```
-androidTestImplementation("com.buildkite.test-collector-android:instrumented-test-collector:0.3.0")
+androidTestImplementation("com.buildkite.test-collector-android:instrumented-test-collector:0.4.0")
 ```
 
 Again, in your app-level build.gradle.kts file, instruct Gradle to use your test collector and pass analytics token argument:


### PR DESCRIPTION
Update README version references from 0.3.0 to 0.4.0 in preparation for the v0.4.0 release.

## Changes since v0.3.0
- Add tagging support at upload and execution levels (#28)
- Add mise configuration for JDK 17
- Add AGENTS.md for agentic coding tools

## Release checklist
- [x] `RunEnvironment.VERSION_NAME` is `"0.4.0"`
- [x] `gradle.properties VERSION_NAME` is `0.4.0-SNAPSHOT` (release workflow strips `-SNAPSHOT`)
- [x] README version references updated to `0.4.0`
- [ ] CI green on this PR
- [ ] Merge to main
- [ ] Create GitHub Release with tag `v0.4.0` → triggers Maven Central publish
- [ ] Verify artifacts on Maven Central
- [ ] Post-release: bump to `0.5.0-SNAPSHOT`